### PR TITLE
DECD-9295 - Fix en Error de validación para vertical Retail de CyberSource

### DIFF
--- a/Decidir/lib/Cybersource/AbstractData.php
+++ b/Decidir/lib/Cybersource/AbstractData.php
@@ -4,27 +4,106 @@ namespace Decidir\Cybersource;
 abstract class AbstractData extends \Decidir\Data\AbstractData
 {	
 	private $field_required = array();
-	
+	private $field_optional = array();
+
 	public function __construct(array $data){
-		$this->dataResponse = $data;
+	    $this->dataResponse = $data;
+	    $simplificatedData = $data;
 		$nameMethod = "";
 
-		foreach($this->field_required as $index => $param){
-			if(array_key_exists($index, $data)){
-				$nameMethod = $param['name'];
-				$this->$nameMethod($index, $this->dataResponse[$index]);
-			}
-		}
+        if(array_key_exists("bill_to", $data)){
+            $bill_to = $data['bill_to'];
+            unset($simplificatedData['bill_to']);
+            $simplificatedData['bill_to'] = array();
+        }
+        if(array_key_exists("ship_to", $data)){
+            $ship_to = $data['ship_to'];
+            unset($simplificatedData['ship_to']);
+            $simplificatedData['ship_to'] = array();
+        }
 
+        parent::setRequiredFields($this->getRequiredFields($data));
+        parent::setOptionalFields($this->getOptionalFields());
+        parent::__construct($simplificatedData);
+
+        foreach($this->field_required as $index => $param){
+            if(array_key_exists($index, $data)){
+                $nameMethod = $param['name'];
+                $this->$nameMethod($index, $this->dataResponse[$index]);
+            }
+        }
+
+        if(array_key_exists("bill_to", $data) || array_key_exists("ship_to", $data)){
+            parent::setRequiredFields($this->getOthersRequiredFields());
+            parent::setOptionalFields($this->getOthersOptionalFields());
+        }
+
+        if(array_key_exists("bill_to", $data)){
+            parent::__construct($bill_to);
+        }
+        if(array_key_exists("ship_to", $data)){
+            parent::__construct($ship_to);
+        }
 	}
 
 	public function setRequiredFields($data){
 		$this->field_required = $data;
 	}
 
+	public function setOptionalFields($data){
+	    $this->field_optional = $data;
+    }
+
+    public function getOthersRequiredFields(){
+        return array(
+            "city" => array(
+                "name" => "setCity"
+            ),
+            "country" => array(
+                "name" => "setCountry"
+            ),
+            "customer_id" => array(
+                "name" => "setCustomerId"
+            ),
+            "email" => array(
+                "name" => "setEmail"
+            ),
+            "first_name" => array(
+                "name" => "setFirstName"
+            ),
+            "last_name" => array(
+                "name" => "setLastName"
+            ),
+            "phone_number" => array(
+                "name" => "setPhoneNumber"
+            ),
+            "postal_code" => array(
+                "name" => "setPostalCode"
+            ),
+            "state" => array(
+                "name" => "setState"
+            ),
+            "street1" => array(
+                "name" => "setStreet1"
+            )
+        );
+    }
+
+    public function getOthersOptionalFields(){
+        return array(
+            "street2" => array(
+                "name" => "setStreet2"
+            )
+        );
+    }
+
 	public function getRequiredFields($data){
 		return $this->field_required;
 	}
+
+	public function getOptionalFields(){
+	    return $this->field_optional;
+    }
 
 	public function getDataField(){
 		return $this->dataResponse;

--- a/Decidir/lib/Cybersource/AbstractData.php
+++ b/Decidir/lib/Cybersource/AbstractData.php
@@ -40,9 +40,11 @@ abstract class AbstractData extends \Decidir\Data\AbstractData
 
         if(array_key_exists("bill_to", $data)){
             parent::__construct($bill_to);
+            $this->dataSet['bill_to'] = $bill_to;
         }
         if(array_key_exists("ship_to", $data)){
             parent::__construct($ship_to);
+            $this->dataSet['retail_transaction_data']['ship_to'] = $ship_to;
         }
 	}
 

--- a/Decidir/lib/Cybersource/Retail.php
+++ b/Decidir/lib/Cybersource/Retail.php
@@ -13,10 +13,10 @@ class Retail extends AbstractData
 
 		$this->setRequiredFields(array(
 			"send_to_cs" => array(
-				"name" => "setChannel"
+				"name" => "setSendToCs"
 			),
 			"channel" => array(
-				"name" => "setSendToCs"
+				"name" => "setChannel"
 			),
 			"bill_to" => array(
 				"name" => "setBillTo"
@@ -67,6 +67,24 @@ class Retail extends AbstractData
 				"name" => "setCouponCode"
 			)
 		));
+
+		$optionalFields = array();
+		for($i = 17; $i <= 34; $i++){
+		    $csmdd = "csmdd" . $i;
+		    $optionalField = array(
+		        "name" => "SetCsmdd" . $i
+            );
+		    $optionalFields[$csmdd] = $optionalField;
+        }
+        for($i = 43; $i <= 99; $i++){
+            $csmdd = "csmdd" . $i;
+            $optionalField = array(
+                "name" => "SetCsmdd" . $i
+            );
+            $optionalFields[$csmdd] = $optionalField;
+        }
+
+        $this->setOptionalFields($optionalFields);
 
 		parent::__construct($retailData);
 

--- a/Decidir/lib/Cybersource/Retail.php
+++ b/Decidir/lib/Cybersource/Retail.php
@@ -8,6 +8,7 @@ class Retail extends AbstractData
 {
 	protected $dataSet = array();
 	protected $products_data = null;
+	protected $products_keys = array("csitproductcode", "csitproductdescription", "csitproductname", "csitproductsku", "csittotalamount", "csitquantity", "csitunitprice");
 
 	public function __construct($retailData, $productsData) {
 
@@ -88,16 +89,20 @@ class Retail extends AbstractData
 
 		parent::__construct($retailData);
 
+		$products = array();
 		foreach($productsData as $index => $product) {
 			foreach($product as $idProd => $value){
 				if($idProd == 'csittotalamount' || $idProd == 'csitunitprice'){
 					$product[$idProd] = ($product[$idProd]*100);
 				}
+                if(in_array($idProd, $this->products_keys)) {
+                    $products[$index][$this->convertKeyProduct($idProd)] = $product[$idProd];
+                }
 			}
 			$this->products_data[] = new Product($product);
 		}
 		$this->setCSMDDS($retailData);
-		$this->setProducts($this->products_data);
+		$this->setProducts($products);
 	}
 
 	public function CsmddsList($data){
@@ -212,5 +217,31 @@ class Retail extends AbstractData
 	public function getData(){
 		return $this->dataSet;
 	}
+
+	public function convertKeyProduct($key){
+	    switch ($key){
+            case "csitproductcode":
+                return "code";
+                break;
+            case "csitproductdescription":
+                return "description";
+                break;
+            case "csitproductname":
+                return "name";
+                break;
+            case "csitproductsku":
+                return "sku";
+                break;
+            case "csittotalamount":
+                return "total_amount";
+                break;
+            case "csitquantity":
+                return "quantity";
+                break;
+            case "csitunitprice":
+                return "unit_price";
+                break;
+        }
+    }
 	
 }

--- a/Decidir/lib/Data/AbstractData.php
+++ b/Decidir/lib/Data/AbstractData.php
@@ -5,6 +5,7 @@ namespace Decidir\Data;
 abstract class AbstractData {
 	protected $dataResponse = array();
 	private $field_required;
+	private $field_optional;
 	
 	public function __construct(array $data){
 		$this->dataResponse = $data;
@@ -15,10 +16,10 @@ abstract class AbstractData {
 
 			foreach ($this->field_required as $key => $value) {
 				if($value['name'] != "" && $key != null){
-					$exist = $this->keyExists($this->dataResponse,$value['name']);
+					$exist = $this->keyExists($this->dataResponse,$key);
 
 					if(!$exist){
-						throw new \Decidir\Exception\RequiredValue($value['name']);
+						throw new \Decidir\Exception\RequiredValue($key);
 					}
 
 				}
@@ -47,7 +48,7 @@ abstract class AbstractData {
 		
 		foreach($fieldValues as $index => $value){
 
-			if(is_array($value)){
+			if(is_array($value) && $index != "fraud_detection"){
 				$this->forValidateFields($value);
 
 			}else{
@@ -55,11 +56,11 @@ abstract class AbstractData {
 				if(array_key_exists($index, $this->field_required)){
 					$this->FieldName = $this->field_required[$index]['name'];
 					
-					if($value == ""){
+					if($value === ""){
 						throw new \Decidir\Exception\EmptyValue($index);
 					}
 
-				}else{
+				}else if(!array_key_exists($index, $this->field_optional)){
 					throw new \Decidir\Exception\AllowValue($index);
 				}
 
@@ -73,6 +74,10 @@ abstract class AbstractData {
 	public function setRequiredFields($data){
 		$this->field_required = $data;
 	}
+
+	public function setOptionalFields($data){
+	    $this->field_optional = $data;
+    }
 
 	public function getRequiredFields($data){
 		return $this->field_required;

--- a/Decidir/lib/Payment/Data.php
+++ b/Decidir/lib/Payment/Data.php
@@ -33,9 +33,6 @@ class Data extends \Decidir\Data\AbstractData {
 			"currency" => array(
 				"name" => "currency"
 			),
-			"description" => array(
-				"name" => "description"
-			),
 			"installments" => array(
 				"name" => "installments"
 			),
@@ -51,9 +48,6 @@ class Data extends \Decidir\Data\AbstractData {
 			"aggregate_data" => array(
 				"name" => ""
 			),
-			"fraud_detection" => array(
-				"name" => "fraud_detection"
-			),
 			"customer" => array(
 				"name" => "customer"
 			),
@@ -61,6 +55,18 @@ class Data extends \Decidir\Data\AbstractData {
 				"name" => ""
 			),
 		));
+
+        $this->setOptionalFields(array(
+            "user_id" => array(
+                "name" => "user_id"
+            ),
+            "description" => array(
+                "name" => "description"
+            ),
+            "fraud_detection" => array(
+				"name" => "fraud_detection"
+			)
+        ));
 
 		parent::__construct($data);
 	}


### PR DESCRIPTION



Nombre | DECD-9295 - Fix en Error de validación para vertical Retail de CyberSource
-- | --
Incidente JIRA | DECD-9295
Descripción del cambio en Ms | Se mejoró el proceso de validación de campos de entrada para la vertical Retail de CyberSource, modificando el mecanismo para campos requeridos y agregando un mecanismo para campos opcionales.Estos cambios se realizaron en los archivos: “Cybersource/AbstractData.php”, “Cybersource.Retail.php” y “Data/AbstractData.php”.
URL a la tarea en JIRA | http://jira.prismamp.com.ar:8080/browse/DECD-9295

