### PR TITLE
DECD-15978 - Envio de Campos opcionales y FP

### DIFF
--- a/Decidir/lib/Cybersource/AbstractData.php
+++ b/Decidir/lib/Cybersource/AbstractData.php
@@ -32,6 +32,13 @@ abstract class AbstractData extends \Decidir\Data\AbstractData
                 $this->$nameMethod($index, $this->dataResponse[$index]);
             }
         }
+        //procesamiento de campos adicionales
+        foreach($this->field_optional as $index => $param){
+            if(array_key_exists($index, $data)){
+                $nameMethod = $param['name'];
+                $this->$nameMethod($index, $this->dataResponse[$index]);
+            }
+        }
 
         if(array_key_exists("bill_to", $data) || array_key_exists("ship_to", $data)){
             parent::setRequiredFields($this->getOthersRequiredFields());

--- a/Decidir/lib/Cybersource/Retail.php
+++ b/Decidir/lib/Cybersource/Retail.php
@@ -69,6 +69,9 @@ class Retail extends AbstractData
             ),
             "coupon_code" => array(
                 "name" => "setCouponCode"
+            ),
+            "device_unique_id" => array(
+            	"name"=> "setDeviceUniqueId"
             )
         );
 
@@ -76,14 +79,14 @@ class Retail extends AbstractData
 		for($i = 17; $i <= 34; $i++){
 		    $csmdd = "csmdd" . $i;
 		    $csmddField = array(
-		        "name" => "SetCsmdd" . $i
+		        "name" => "SetCsmdds" 
             );
             $csmddFields[$csmdd] = $csmddField;
         }
         for($i = 43; $i <= 99; $i++){
             $csmdd = "csmdd" . $i;
             $csmddField = array(
-                "name" => "SetCsmdd" . $i
+                "name" => "SetCsmdds"
             );
             $csmddFields[$csmdd] = $csmddField;
         }


### PR DESCRIPTION
<b style="font-weight:normal;" id="docs-internal-guid-0933ba73-7fff-50e5-50f4-c2430f2093eb"><div dir="ltr" style="margin-left:0pt;" align="left">

Nombre | DECD-15978 - Envío de Campos opcionales y FP
-- | --
Incidente JIRA | DECD-15978
Descripción del cambio | Se incorporó el código de procesamiento de campos adicionales y el campo “device_unique_id” como campo adicional a remitir a CS.
URL a la tarea en JIRA | https://jira.prismamp.com/browse/DECD-15978

</div></b>