### PR TITLE
FPP18-97 - Eliminación de logueo en  apache

### DIFF
--- a/Decidir/lib/RESTClient.php
+++ b/Decidir/lib/RESTClient.php
@@ -118,9 +118,6 @@ class RESTClient{
 			array_push($header_http, 'apikey: '. $this->key);
 		}	
 
-		error_log(print_r($header_http,true),3,"/var/log/apache2/error_log.log");
-
-
 		$curl = curl_init();
 		$curl_post_data = array();
 


### PR DESCRIPTION
<b style="font-weight:normal;" id="docs-internal-guid-ba430f09-7fff-3c8e-019b-210b71df9f96"><div dir="ltr" style="margin-left:0pt;" align="left">

Nombre | FPP18-97 - Eliminación de logueo en  apache
-- | --
Incidente JIRA | FPP18-97
Descripción del cambio | Se elimina la línea de logueo forzado en apache, dado que la sintaxis no presenta funcionalidad relevante para el SDK-PHP
URL a la tarea en JIRA | https://jira.prismamp.com/browse/FPP18-97

</div></b>